### PR TITLE
Add interpolation note for dynamic-login password

### DIFF
--- a/diskimage_builder/elements/dynamic-login/README.rst
+++ b/diskimage_builder/elements/dynamic-login/README.rst
@@ -27,14 +27,15 @@ rootpwd
   :Description: If the operator append rootpwd="$ENCRYPTED_PASSWORD" to the
                 kernel command line on boot, the helper script will set the
                 root password to the one specified by this option. Note that
-                this password must be **encrypted**. Encrypted passwords
-                can be generated using the ``openssl`` command, e.g:
-                *openssl passwd -1*.
+                this password must be **encrypted**. Interpolation can be 
+                avoided by using $$. Encrypted passwords can be generated 
+                using the ``openssl`` command, e.g: *openssl passwd -1 
+                -stdin <<< YOUR_PASSWORD | sed 's/\$/\$$/g'*. 
 
 
 .. note::
    The value of these parameters must be **quoted**, e.g: sshkey="ssh-rsa
-   BBBA1NBzaC1yc2E ..."
+   BBBA1NBzaC1yc2E ...".
 
 
 .. warning::

--- a/diskimage_builder/elements/dynamic-login/README.rst
+++ b/diskimage_builder/elements/dynamic-login/README.rst
@@ -35,7 +35,7 @@ rootpwd
 
 .. note::
    The value of these parameters must be **quoted**, e.g: sshkey="ssh-rsa
-   BBBA1NBzaC1yc2E ...".
+   BBBA1NBzaC1yc2E ..."
 
 
 .. warning::


### PR DESCRIPTION
see oslo config parser bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1807871
https://docs.openstack.org/oslo.config/latest/reference/configuration-files.html#option-value-interpolation